### PR TITLE
Change the scope of the osc object

### DIFF
--- a/src/osc/tunneling.js
+++ b/src/osc/tunneling.js
@@ -1,19 +1,15 @@
 import { Client, Message } from 'browserglue';
 
-
-
-const osc = new Client();
-
-let boton1 = false;
+let osc;
 
 let funciones = [];
 
-
-export function botonOsc() {
-    return boton1;
-}
-
 function activarOSC(nombreCanal, puertoRecibir) {
+    if (osc) {
+        console.log("OSC ya está activo");
+        return;
+    }
+    osc = new Client();
 
     console.log("Add channel " + nombreCanal + " binded to udp: " + puertoRecibir);
 


### PR DESCRIPTION
so that it doesn't trigger errors if activarOSC hasn't been called

## Previously

Since we were calling 

```js
const osc = new Client();
```

at the module scope, if the user hadn't yet initialized the `browserglue` server, the browser console was filled with errors at the app's start from the `Client` pooling for the `browserglue` server to be active


## Currently

The `new Client` call is not done at the module scope level, but inisde a function that the user must call after having activated or ran the `browserglue` client, so no errors are being triggered at the app start