### PR TITLE
Oculta el botón "iniciar" una vez el arduino está conectado

### DIFF
--- a/src/j5/controlSystem.js
+++ b/src/j5/controlSystem.js
@@ -20,6 +20,7 @@ function handleIOReady(io) {
     board.on('ready', () => {
       console.log('johnny five in browser !!!!');
       document.getElementById('board-overlay')?.classList.add('board-ready');
+      window.dispatchEvent(new CustomEvent('arduino-ready'));
     });
     board.on('error', console.error);
   }

--- a/src/ui/gui.js
+++ b/src/ui/gui.js
@@ -9,7 +9,15 @@ const gui = new GUI();
 
 gui.add(window.location, 'reload').name('recargar');
 
-gui.add({ init }, 'init').name('iniciar');
+const initArduinoController = gui.add({ init }, 'init').name('iniciar');
+
+// Una vez el arduino está conectado e identificado (evento 'ready' de
+// johnny-five, ver controlSystem.js) ya no hace falta el botón "iniciar".
+// Se escucha por evento en vez de importar controlSystem.js directamente
+// para evitar una dependencia circular (gui.js -> init.js -> controlSystem.js).
+window.addEventListener('arduino-ready', () => {
+  initArduinoController.destroy();
+}, { once: true });
 
 export function setupThemeController(editor) {
   const themeController = new ThemeController(editor, gui);


### PR DESCRIPTION
controlSystem.js dispara un evento arduino-ready en window dentro del mismo board.on('ready') que ya quita la opacidad del overlay. gui.js escucha ese evento una sola vez y destruye el control "iniciar", ya que no se necesita una vez el arduino quedó conectado e identificado. Se usa un evento en window en vez de un import directo para evitar una dependencia circular (gui.js -> init.js -> controlSystem.js -> gui.js).